### PR TITLE
fix twig `ExpressionParser` being deprecated with v3.21

### DIFF
--- a/src/twigextensions/tokenparsers/ExecuteScriptTokenParser.php
+++ b/src/twigextensions/tokenparsers/ExecuteScriptTokenParser.php
@@ -27,13 +27,11 @@ class ExecuteScriptTokenParser extends AbstractTokenParser
         $lineno = $token->getLine();
         $parser = $this->parser;
         $stream = $parser->getStream();
-        $expressionParser = $parser->getExpressionParser();
-
         $nodes = [];
 
         if ($stream->test(Token::NAME_TYPE, 'with')) {
             $stream->next();
-            $nodes['options'] = $expressionParser->parseExpression();
+            $nodes['options'] = $parser->parseExpression();
         }
 
         $stream->expect(Token::BLOCK_END_TYPE);

--- a/src/twigextensions/tokenparsers/FragmentTokenParser.php
+++ b/src/twigextensions/tokenparsers/FragmentTokenParser.php
@@ -27,17 +27,15 @@ class FragmentTokenParser extends AbstractTokenParser
         $lineno = $token->getLine();
         $parser = $this->parser;
         $stream = $parser->getStream();
-        $expressionParser = $parser->getExpressionParser();
-
         $nodes = [];
 
         if ($stream->test(Token::NAME_TYPE, 'remove')) {
             $stream->next();
-            $nodes['selector'] = $expressionParser->parseExpression();
+            $nodes['selector'] = $parser->parseExpression();
         } else {
             if ($stream->test(Token::NAME_TYPE, 'with')) {
                 $stream->next();
-                $nodes['options'] = $expressionParser->parseExpression();
+                $nodes['options'] = $parser->parseExpression();
             }
 
             $stream->expect(Token::BLOCK_END_TYPE);

--- a/src/twigextensions/tokenparsers/LocationTokenParser.php
+++ b/src/twigextensions/tokenparsers/LocationTokenParser.php
@@ -27,14 +27,13 @@ class LocationTokenParser extends AbstractTokenParser
         $lineno = $token->getLine();
         $parser = $this->parser;
         $stream = $parser->getStream();
-        $expressionParser = $parser->getExpressionParser();
 
         $nodes = [];
-        $nodes['uri'] = $expressionParser->parseExpression();
+        $nodes['uri'] = $parser->parseExpression();
 
         if ($stream->test(Token::NAME_TYPE, 'with')) {
             $stream->next();
-            $nodes['options'] = $expressionParser->parseExpression();
+            $nodes['options'] = $parser->parseExpression();
         }
 
         $stream->expect(Token::BLOCK_END_TYPE);

--- a/src/twigextensions/tokenparsers/SleepTokenParser.php
+++ b/src/twigextensions/tokenparsers/SleepTokenParser.php
@@ -28,10 +28,9 @@ class SleepTokenParser extends AbstractTokenParser
         $lineno = $token->getLine();
         $parser = $this->parser;
         $stream = $parser->getStream();
-        $expressionParser = $parser->getExpressionParser();
 
         $nodes = [];
-        $nodes['duration'] = $expressionParser->parseExpression();
+        $nodes['duration'] = $parser->parseExpression();
 
         if ($stream->test(Token::NAME_TYPE, 'ms')) {
             $stream->next();


### PR DESCRIPTION
See https://github.com/twigphp/Twig/blob/3.x/CHANGELOG

> # 3.21.0 (2025-05-02)
> 
>  ...
>  * Deprecate the `Twig\ExpressionParser`, and `Twig\OperatorPrecedenceChange` classes

or https://github.com/twigphp/Twig/blob/3.x/doc/deprecated.rst

> * The ``Twig\Parser::getExpressionParser()`` method is deprecated as of Twig
>   3.21, use ``Twig\Parser::parseExpression()`` instead.
> * The ``Twig\ExpressionParser`` class is deprecated as of Twig 3.21:
>   * ``parseExpression()``, use ``Parser::parseExpression()``
>   * ``parsePrimaryExpression()``, use ``Parser::parseExpression()``
>   * ``parseStringExpression()``, use ``Parser::parseExpression()``
>   * ``parseHashExpression()``, use ``Parser::parseExpression()``
>   * ``parseMappingExpression()``, use ``Parser::parseExpression()``
>   * ``parseArrayExpression()``, use ``Parser::parseExpression()``
>   * ``parseSequenceExpression()``, use ``Parser::parseExpression()``
>   * ``parsePostfixExpression``
>   * ``parseSubscriptExpression``
>   * ``parseFilterExpression``
>   * ``parseFilterExpressionRaw``
>   * ``parseArguments()``, use ``Twig\ExpressionParser\Infix\ArgumentsTrait::parseNamedArguments()``
>   * ``parseAssignmentExpression``, use ``AbstractTokenParser::parseAssignmentExpression``
>   * ``parseMultitargetExpression``
>   * ``parseOnlyArguments()``, use ``Twig\ExpressionParser\Infix\ArgumentsTrait::parseNamedArguments()``

This PR therefore replaces ``Twig\Parser::getExpressionParser()`` calls with ``Twig\Parser::parseExpression()``

``Twig\Parser::parseExpression()`` is available from Twig v3.21.0. Since craftCMS is on ~3.15.0, this PR does not apply to all installations yet.